### PR TITLE
Waystones (Polymer Port) compatibility

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,6 +25,6 @@
     "fabricloader": ">=0.13.3",
     "minecraft": "~1.18.2",
     "fabric": ">=0.47.8",
-    "waystones": ">=2.5.0"
+    "waystones": ">=2.5.0-polymerport.0"
   }
 }


### PR DESCRIPTION
As this mod now requires [Fabric Waystones](https://github.com/LordDeatHunter/FabricWaystones) to work (tho from the repo README it seems it's not supposed to work that way?), you can't use it on server-side only anymore. This change allows for use of [Waystones (Polymer Port)](https://github.com/PolymerPorts/FabricWaystones) instead of Fabric Waystones if the mod is installed on server only. You can still use normal Fabric Waystones with this change. 

Here's a screenshot of the mod running on client with Fabric Waystones:
![2022-04-02_17 46 15](https://user-images.githubusercontent.com/68301723/161392007-65774488-8099-43d4-87c1-9e6344ce7d4d.png)

Modded client on modded server with Fabric Waystones:
![2022-04-02_18 33 46](https://user-images.githubusercontent.com/68301723/161392444-161e8abe-cdd7-4cf5-9adf-b408539de2e0.png)


Vanilla client on modded server with Waystones (Polymer Port):
![2022-04-02_17 49 21](https://user-images.githubusercontent.com/68301723/161392049-21f951c2-94ec-4325-8972-19ea08cc3daf.png)
